### PR TITLE
Expose disabling decoder loading for classification and regression tasks

### DIFF
--- a/asparagus/modules/lightning_modules/clsreg_module.py
+++ b/asparagus/modules/lightning_modules/clsreg_module.py
@@ -33,6 +33,7 @@ class ClsRegBase(BaseModule):
         momentum: float = 0.99,
         log_image_every_n_epochs: int = 50,
         test_output_path: str = None,
+        load_decoder: bool = True,
         repeat_stem_weights: bool = True,
     ):
         super().__init__(
@@ -50,6 +51,7 @@ class ClsRegBase(BaseModule):
             weight_decay=weight_decay,
             nesterov=nesterov,
             momentum=momentum,
+            load_decoder=load_decoder,
             repeat_stem_weights=repeat_stem_weights,
         )
         self.loss = None

--- a/asparagus/pipeline/run/finetune_cls.py
+++ b/asparagus/pipeline/run/finetune_cls.py
@@ -114,6 +114,7 @@ def main(cfg: DictConfig) -> None:
         log_image_every_n_epochs=cfg.logger.log_images_every_n_epoch,
         optimizer=cfg.model.finetune_optim,
         learning_rate=cfg.model.finetune_lr,
+        load_decoder=cfg.training.load_decoder,
         repeat_stem_weights=cfg.training.repeat_stem_weights,
         test_output_path=os.path.join(
             path_store.run_dir,

--- a/asparagus/pipeline/run/finetune_reg.py
+++ b/asparagus/pipeline/run/finetune_reg.py
@@ -114,6 +114,7 @@ def main(cfg: DictConfig) -> None:
         learning_rate=cfg.model.finetune_lr,
         warmup_epochs=cfg.training.warmup_epochs,
         weight_decay=cfg.model.weight_decay,
+        load_decoder=cfg.training.load_decoder,
         test_output_path=os.path.join(
             path_store.run_dir,
             "predictions",

--- a/configs/default_finetune_cls.yaml
+++ b/configs/default_finetune_cls.yaml
@@ -35,6 +35,7 @@ training:
   mask_ratio: 0.0
   check_val_every_n_epoch: 3
   accumulate_grad_batches: 1
+  load_decoder: True
   repeat_stem_weights: True
 
 transforms:

--- a/configs/default_finetune_reg.yaml
+++ b/configs/default_finetune_reg.yaml
@@ -32,6 +32,7 @@ training:
   accumulate_grad_batches: 1
   warmup_epochs: 0
   check_val_every_n_epoch: 1
+  load_decoder: True
 
 transforms:
   cpu_tr_transforms: CPU_clsreg_train_transforms_crop


### PR DESCRIPTION
Cls/reg fine-tuning previously could not override `load_decoder` even though `BaseModule` supported it. `ClassificationModule` and `RegressionModule` both go through `ClsRegBase`, and `ClsRegBase.__init__` did not accept or forward a `load_decoder` argument. As a result, `BaseModule` always used its default `load_decoder=True` for cls/reg checkpoint loading.

This change makes the option explicit for cls/reg fine-tuning by adding `load_decoder` to `ClsRegBase`, forwarding it to `BaseModule`, adding `training.load_decoder: True` to the default cls/reg fine-tune configs, and passing that config value from `finetune_cls.py` and `finetune_reg.py`.

The default behavior is unchanged: cls/reg still load decoder weights by default. The difference is that users can now override the behavior from config or CLI, for example:

```bash
asp_finetune_cls training.load_decoder=False
asp_finetune_reg training.load_decoder=False
```

Imo, it makes sense to not load decoder in many classification and regression cases.