### PR TITLE
Allow setting wandb project names

### DIFF
--- a/asparagus/pipeline/run/finetune_cls.py
+++ b/asparagus/pipeline/run/finetune_cls.py
@@ -51,7 +51,7 @@ def main(cfg: DictConfig) -> None:
         version=version_store.version,
         wandb_config=logging_safe_cfg,
         wandb_experiment=HydraConfig.get().job.config_name,
-        wandb_project="Finetune",
+        wandb_project=cfg.logger.wandb_project,
         wandb_logging=cfg.logger.wandb_logging,
         mlflow_logging=cfg.logger.mlflow_logging,
         log_to_stdout=cfg.logger.log_to_stdout,

--- a/asparagus/pipeline/run/finetune_reg.py
+++ b/asparagus/pipeline/run/finetune_reg.py
@@ -51,7 +51,7 @@ def main(cfg: DictConfig) -> None:
         version=version_store.version,
         wandb_experiment=HydraConfig.get().job.config_name,
         wandb_entity=cfg.logger.wandb_entity,
-        wandb_project="Finetune",
+        wandb_project=cfg.logger.wandb_project,
         wandb_logging=cfg.logger.wandb_logging,
         mlflow_logging=cfg.logger.mlflow_logging,
         log_to_stdout=cfg.logger.log_to_stdout,

--- a/asparagus/pipeline/run/finetune_seg.py
+++ b/asparagus/pipeline/run/finetune_seg.py
@@ -53,7 +53,7 @@ def main(cfg: DictConfig) -> None:
         version=version_store.version,
         wandb_config=logging_safe_cfg,
         wandb_experiment=HydraConfig.get().job.config_name,
-        wandb_project=cfg.task,
+        wandb_project=cfg.logger.wandb_project,
         wandb_logging=cfg.logger.wandb_logging,
         mlflow_logging=cfg.logger.mlflow_logging,
         log_to_stdout=cfg.logger.log_to_stdout,

--- a/asparagus/pipeline/run/linear_probe.py
+++ b/asparagus/pipeline/run/linear_probe.py
@@ -49,7 +49,7 @@ def main(cfg: DictConfig) -> None:
         version=version_store.version,
         wandb_config=logging_safe_cfg,
         wandb_experiment=HydraConfig.get().job.config_name,
-        wandb_project="LinearProbe",
+        wandb_project=cfg.logger.wandb_project,
         wandb_logging=cfg.logger.wandb_logging,
         mlflow_logging=cfg.logger.mlflow_logging,
     )

--- a/asparagus/pipeline/run/pretrain.py
+++ b/asparagus/pipeline/run/pretrain.py
@@ -44,7 +44,7 @@ def main(cfg: DictConfig) -> None:
         version=version_store.version,
         wandb_config=logging_safe_cfg,
         wandb_experiment=HydraConfig.get().job.config_name,
-        wandb_project="Pretrain",
+        wandb_project=cfg.logger.wandb_project,
         wandb_logging=cfg.logger.wandb_logging,
         mlflow_logging=cfg.logger.mlflow_logging,
         log_to_stdout=cfg.logger.log_to_stdout,

--- a/asparagus/pipeline/run/train_cls.py
+++ b/asparagus/pipeline/run/train_cls.py
@@ -50,6 +50,7 @@ def main(cfg: DictConfig) -> None:
         wandb_config=logging_safe_cfg,
         wandb_experiment=HydraConfig.get().job.config_name,
         wandb_entity=cfg.logger.wandb_entity,
+        wandb_project=cfg.logger.wandb_project,
         wandb_logging=cfg.logger.wandb_logging,
         mlflow_logging=cfg.logger.mlflow_logging,
         log_to_stdout=cfg.logger.log_to_stdout,

--- a/asparagus/pipeline/run/train_reg.py
+++ b/asparagus/pipeline/run/train_reg.py
@@ -50,6 +50,7 @@ def main(cfg: DictConfig) -> None:
         wandb_config=logging_safe_cfg,
         wandb_experiment=HydraConfig.get().job.config_name,
         wandb_entity=cfg.logger.wandb_entity,
+        wandb_project=cfg.logger.wandb_project,
         wandb_logging=cfg.logger.wandb_logging,
         mlflow_logging=cfg.logger.mlflow_logging,
         log_to_stdout=cfg.logger.log_to_stdout,

--- a/asparagus/pipeline/run/train_seg.py
+++ b/asparagus/pipeline/run/train_seg.py
@@ -49,7 +49,7 @@ def main(cfg: DictConfig) -> None:
         version=version_store.version,
         wandb_config=logging_safe_cfg,
         wandb_experiment=HydraConfig.get().job.config_name,
-        wandb_project=cfg.task,
+        wandb_project=cfg.logger.wandb_project,
         wandb_logging=cfg.logger.wandb_logging,
         mlflow_logging=cfg.logger.mlflow_logging,
         log_to_stdout=cfg.logger.log_to_stdout,

--- a/configs/default_finetune_cls.yaml
+++ b/configs/default_finetune_cls.yaml
@@ -51,6 +51,7 @@ logger:
   wandb_log_model: False
   wandb_logging: True
   wandb_entity: ${oc.env:WANDB_ENTITY, "team-asparagus"}
+  wandb_project: Finetune
   mlflow_logging: False
   log_every_n_steps: 250
   log_images_every_n_epoch: 5

--- a/configs/default_finetune_reg.yaml
+++ b/configs/default_finetune_reg.yaml
@@ -47,6 +47,7 @@ logger:
   wandb_log_model: False
   wandb_logging: True
   wandb_entity: ${oc.env:WANDB_ENTITY, "team-asparagus"}
+  wandb_project: Finetune
   mlflow_logging: False
   log_every_n_steps: 250
   log_images_every_n_epoch: 5

--- a/configs/default_finetune_seg.yaml
+++ b/configs/default_finetune_seg.yaml
@@ -51,6 +51,7 @@ logger:
   wandb_log_model: False
   wandb_logging: True
   wandb_entity: ${oc.env:WANDB_ENTITY, "team-asparagus"}
+  wandb_project: ${task}
   mlflow_logging: False
   log_every_n_steps: 50
   log_images_every_n_epoch: 5

--- a/configs/default_linear_probe.yaml
+++ b/configs/default_linear_probe.yaml
@@ -47,6 +47,7 @@ logger:
   progress_bar: True
   wandb_logging: True
   wandb_entity: ${oc.env:WANDB_ENTITY, "team-asparagus"}
+  wandb_project: LinearProbe
   mlflow_logging: False
   log_every_n_steps: 25
   log_images_every_n_epoch: 9999999

--- a/configs/default_pretrain.yaml
+++ b/configs/default_pretrain.yaml
@@ -70,6 +70,7 @@ logger:
   wandb_log_model: False
   wandb_logging: True
   wandb_entity: ${oc.env:WANDB_ENTITY, "team-asparagus"}
+  wandb_project: Pretrain
   mlflow_logging: False
   log_every_n_steps: 250
   log_images_every_n_epoch: 5

--- a/configs/default_train_cls.yaml
+++ b/configs/default_train_cls.yaml
@@ -49,6 +49,7 @@ logger:
   wandb_log_model: False
   wandb_logging: True
   wandb_entity: ${oc.env:WANDB_ENTITY, "team-asparagus"}
+  wandb_project: Asparagus
   mlflow_logging: False
   log_every_n_steps: 250
   log_images_every_n_epoch: 5

--- a/configs/default_train_reg.yaml
+++ b/configs/default_train_reg.yaml
@@ -48,6 +48,7 @@ logger:
   wandb_log_model: False
   wandb_logging: True
   wandb_entity: ${oc.env:WANDB_ENTITY, "team-asparagus"}
+  wandb_project: Asparagus
   mlflow_logging: False
   log_every_n_steps: 250
   log_images_every_n_epoch: 1

--- a/configs/default_train_seg.yaml
+++ b/configs/default_train_seg.yaml
@@ -48,6 +48,7 @@ logger:
   wandb_log_model: False
   wandb_logging: True
   wandb_entity: ${oc.env:WANDB_ENTITY, "team-asparagus"}
+  wandb_project: ${task}
   mlflow_logging: False
   log_images_every_n_epoch: 1
   log_every_n_steps: 250


### PR DESCRIPTION
Adds configurable W&B project names via `logger.wandb_project`.

Previously, several run entry points hardcoded the W&B project name, while others relied on the shared logger default or used `cfg.task`. This PR moves those values into the default Hydra configs and updates all training/finetuning entry points to pass `cfg.logger.wandb_project` to the logger.

Current behavior is preserved by default:
- finetune cls/reg: `Finetune`
- pretrain: `Pretrain`
- linear probe: `LinearProbe`
- train cls/reg: `Asparagus`
- train/finetune seg: `${task}`

Users can now override the project name from config or CLI, e.g. `logger.wandb_project=MyProject`.