### PR TITLE
Fix classification labels for batch size 1

### DIFF
--- a/asparagus/modules/lightning_modules/clsreg_module.py
+++ b/asparagus/modules/lightning_modules/clsreg_module.py
@@ -188,7 +188,7 @@ class ClassificationModule(ClsRegBase):
         )
 
     def on_before_batch_transfer(self, batch, dataloader_idx):
-        batch["CLSREG_label"] = batch["CLSREG_label"].squeeze().long()
+        batch["CLSREG_label"] = batch["CLSREG_label"].view(-1).long()
         return batch
 
     def on_test_batch_end(self, outputs, batch, batch_idx, dataloader_idx=0):


### PR DESCRIPTION
When using `batch_size=1` for smoke tests, `squeeze()` turns a [1, 1] label tensor into a scalar for batch_size=1,
which breaks CrossEntropyLoss with a batch-size mismatch. `view(-1)`keeps labels shaped as [B].

For batch sizes other than 1, the behavior remains the same.