### PR TITLE
Add F1 score to linear probing task

### DIFF
--- a/asparagus/modules/lightning_modules/linear_probe_module.py
+++ b/asparagus/modules/lightning_modules/linear_probe_module.py
@@ -207,9 +207,7 @@ class LinearProbeModule(BaseModule):
                     f"{prefix}/{head_name}/auprc_macro": MulticlassAveragePrecision(
                         num_classes=self.num_classes, average="macro"
                     ),
-                    f"{prefix}/{head_name}/f1_macro": MulticlassF1Score(
-                        num_classes=self.num_classes, average="macro"
-                    ),
+                    f"{prefix}/{head_name}/f1_macro": MulticlassF1Score(num_classes=self.num_classes, average="macro"),
                 }
             )
         return metrics

--- a/asparagus/modules/lightning_modules/linear_probe_module.py
+++ b/asparagus/modules/lightning_modules/linear_probe_module.py
@@ -11,6 +11,7 @@ from torchmetrics import MetricCollection
 from torchmetrics.classification import (
     MulticlassAUROC,
     MulticlassAveragePrecision,
+    MulticlassF1Score,
 )
 from torchvision import transforms
 from typing import List, Optional
@@ -192,6 +193,7 @@ class LinearProbeModule(BaseModule):
             {
                 "AUROC_macro": MulticlassAUROC(num_classes=self.num_classes, average="macro"),
                 "AUPRC_macro": MulticlassAveragePrecision(num_classes=self.num_classes, average="macro"),
+                "F1_macro": MulticlassF1Score(num_classes=self.num_classes, average="macro"),
             }
         )
 
@@ -203,6 +205,9 @@ class LinearProbeModule(BaseModule):
                 {
                     f"{prefix}/{head_name}/auroc_macro": MulticlassAUROC(num_classes=self.num_classes, average="macro"),
                     f"{prefix}/{head_name}/auprc_macro": MulticlassAveragePrecision(
+                        num_classes=self.num_classes, average="macro"
+                    ),
+                    f"{prefix}/{head_name}/f1_macro": MulticlassF1Score(
                         num_classes=self.num_classes, average="macro"
                     ),
                 }


### PR DESCRIPTION
F1 score should be calculated as part of Task 6 evaluation:
<img width="956" height="519" alt="image" src="https://github.com/user-attachments/assets/fcf4a086-7006-4567-bc25-6e29c7810122" />

This PR adds it.
