### PR TITLE
chore: max epochs -> epochs

### DIFF
--- a/asparagus/pipeline/run/linear_probe.py
+++ b/asparagus/pipeline/run/linear_probe.py
@@ -104,7 +104,7 @@ def main(cfg: DictConfig) -> None:
         logger=loggers,
         profiler=None,
         default_root_dir=path_store.run_dir,
-        max_epochs=cfg.training.max_epochs,
+        max_epochs=cfg.training.epochs,
         check_val_every_n_epoch=cfg.training.check_val_every_n_epoch,
         limit_train_batches=cfg.training.limit_train_batches,
         limit_val_batches=cfg.training.limit_val_batches,

--- a/configs/default_linear_probe.yaml
+++ b/configs/default_linear_probe.yaml
@@ -24,7 +24,7 @@ data:
 
 training:
   warmup_epochs: 0
-  max_epochs: 15
+  epochs: 15
   batch_size: 4
   limit_train_batches: 1.0
   limit_val_batches: 1.0


### PR DESCRIPTION
All the configs other than `linear_probing` are using `training.epochs` parameter. 
This PR normalizes the config parameter across all tasks.
